### PR TITLE
Update documentation to introduce 'Publishing as Template' section, r…

### DIFF
--- a/creators/become-a-creator.mdx
+++ b/creators/become-a-creator.mdx
@@ -21,6 +21,18 @@ icon: "pencil-ruler"
   </Step>
   <Step>
     <Card
+      title="Publish your first interactive document as template"
+      icon="rss"
+      horizontal
+      href="/creators/publishing-as-template"
+      arrow="true"
+    >
+      You can learn more about the best pratices when publishing your doc on our
+      open source community
+    </Card>
+  </Step>
+  <Step>
+    <Card
       title="You're ready to start earning!"
       icon="hand-coins"
       horizontal

--- a/creators/publishing-as-template.mdx
+++ b/creators/publishing-as-template.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Publishing"
-description: "Contribute to the open source community by publishing your doc on the hub, making it accessible for anyone to use."
+title: "Publishing as Template"
+description: "Contribute to the open source community by publishing your doc on the hub, making it an accessible template for anyone to use."
 icon: "rss"
 ---
 

--- a/creators/start-earning.mdx
+++ b/creators/start-earning.mdx
@@ -37,10 +37,10 @@ Try our interactive calculator to see exactly how much you can earn:
 - **Document Well**: Clear instructions increase adoption
 - **Network**: Connect with other creators in the community
 
-## Ready to Start?
+## Ready?
 
-Begin your earning journey by [creating your first app](/creators/become-a-creator) or [learning about our publishing process](/creators/publishing).
+Begin your earning journey by [creating your first app](/creators/become-a-creator) or [learning about our publishing process](/creators/publishing-as-template).
 
 ---
 
-_Have questions about earning? Check out our [creator guidelines](/creators/content-guidelines) or reach out to our support team._
+_Have questions about earning? reach out to our [support team](mailto:contact@davia.ai)._

--- a/docs.json
+++ b/docs.json
@@ -36,8 +36,8 @@
         "group": "Creators",
         "pages": [
           "creators/become-a-creator",
+          "creators/publishing-as-template",
           "creators/start-earning",
-          "creators/publishing",
           "creators/open-source-community"
         ]
       },

--- a/overview.mdx
+++ b/overview.mdx
@@ -88,21 +88,22 @@ Access in right sidepane with command ⌘K or by clicking on the <ChatIcon /> ic
     Follow the steps to get verified and become a creator.
   </Card>
   <Card
+    title="Publish as templates in seconds"
+    icon="rss"
+    href="creators/publishing-as-template"
+    arrow="true"
+  >
+    Once your document is ready, publish it as a reusable template on our open
+    source doc hub.
+  </Card>
+  <Card
     title="Start Earning"
     icon="hand-coins"
     href="creators/start-earning"
     arrow="true"
   >
-    Monetize the usage of your publised docs. Click here for our monetizing
+    Monetize the usage of your published docs. Click here for our monetizing
     policy.
-  </Card>
-  <Card
-    title="Publish in seconds"
-    icon="rss"
-    href="creators/publishing"
-    arrow="true"
-  >
-    Once your document is ready, publish it on the public doc hub.
   </Card>
   <Card
     title="Share on our socials"


### PR DESCRIPTION
…evise 'Start Earning' and 'Become a Creator' content for clarity, and adjust links to reflect new publishing process. Add new page for 'Publishing as Template' with guidelines for sharing interactive documents.