### PR TITLE
Update documentation to include new CLI commands reference and supported agents + added open code

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -45,7 +45,7 @@
       },
       {
         "group": "Reference",
-        "pages": ["cli-commands"],
+        "pages": ["reference/cli-commands", "reference/supported-agents"],
         "icon": "book"
       },
       {

--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -29,12 +29,16 @@ Before installing the Davia CLI, make sure you have Node.js and npm installed. Y
     davia init --agent=cursor
     ```
 
-     ```bash Claude Code
+    ```bash Claude Code
     davia init --agent=claude-code
     ```
 
     ```bash Github Copilot
     davia init --agent=github-copilot
+    ```
+
+    ```bash Open Code
+    davia init --agent=open-code
     ```
 
     ```bash Windsurf

--- a/reference/cli-commands.mdx
+++ b/reference/cli-commands.mdx
@@ -6,9 +6,9 @@ description: "Reference for all Davia CLI commands."
 <ParamField header="davia init" type="command">
   Initialize Davia in current directory. Creates `.davia` folder and project configuration.
 
-| Option           | Description                                                |
-| ---------------- | ---------------------------------------------------------- |
-| `--agent=<name>` | Specify AI coding agent (cursor, github-copilot, windsurf) |
+| Option           | Description                                                                        |
+| ---------------- | ---------------------------------------------------------------------------------- |
+| `--agent=<name>` | Specify AI coding agent (cursor, claude-code, github-copilot, windsurf, open-code) |
 
 </ParamField>
 

--- a/reference/supported-agents.mdx
+++ b/reference/supported-agents.mdx
@@ -1,0 +1,12 @@
+---
+title: "Supported coding agents"
+description: "List of coding agents you can connect to Davia and the values to use with the <code>agent</code> flag."
+---
+
+| Agent          | <code>agent</code> value    |
+| -------------- | --------------------------- |
+| Cursor         | <code>cursor</code>         |
+| Claude Code    | <code>claude-code</code>    |
+| GitHub Copilot | <code>github-copilot</code> |
+| Windsurf       | <code>windsurf</code>       |
+| Open Code      | <code>open-code</code>      |


### PR DESCRIPTION
 Modify 'docs.json' to reflect the new pages, and enhance 'Quickstart' with additional agent examples.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Reference pages for CLI commands and supported agents, and updates Quickstart/CLI docs to include the Open Code agent.
> 
> - **Documentation**:
>   - **Navigation (`docs.json`)**: Update Reference pages to `reference/cli-commands` and add `reference/supported-agents`.
>   - **Quickstart (`quickstart.mdx`)**: Add `open-code` example to `davia init --agent` CodeGroup.
>   - **CLI Reference (`reference/cli-commands.mdx`)**: Expand `--agent=<name>` options to include `claude-code` and `open-code`.
>   - **New Page (`reference/supported-agents.mdx`)**: List supported agents and their `agent` flag values (`cursor`, `claude-code`, `github-copilot`, `windsurf`, `open-code`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit af5e9e1ad3b45598fb669c560b2bcb8bebedb9ab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->